### PR TITLE
Fixed players being able to transfer skill items

### DIFF
--- a/src/main/java/me/dueris/genesismc/core/factory/powers/entity/Phantomized.java
+++ b/src/main/java/me/dueris/genesismc/core/factory/powers/entity/Phantomized.java
@@ -11,6 +11,10 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.*;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -271,6 +275,54 @@ public class Phantomized extends BukkitRunnable implements Listener {
         if (phantomize.contains(e.getPlayer())) {
             if (e.getItemDrop().getItemStack().isSimilar(spectatorswitch)) {
                 e.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onTransfer(InventoryClickEvent e) {
+        if(e.getClick().isKeyboardClick()) {
+            if(e.getView().getTopInventory().getType() == InventoryType.CRAFTING) return;
+            if(e.getView().getBottomInventory().getItem(e.getHotbarButton()) != null) {
+                ItemStack transferred = e.getView().getBottomInventory().getItem(e.getHotbarButton());
+                if(transferred.getType().equals(Material.PHANTOM_MEMBRANE)) {
+                    ItemStack spectatorswitch = new ItemStack(Material.PHANTOM_MEMBRANE);
+                    ItemMeta switch_meta = spectatorswitch.getItemMeta();
+                    switch_meta.setDisplayName(GRAY + "Phantom Form");
+                    ArrayList<String> pearl_lore = new ArrayList();
+                    switch_meta.setUnbreakable(true);
+                    switch_meta.addEnchant(Enchantment.ARROW_INFINITE, 1, true);
+                    switch_meta.addItemFlags(ItemFlag.HIDE_ITEM_SPECIFICS);
+                    switch_meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                    switch_meta.setLore(pearl_lore);
+                    spectatorswitch.setItemMeta(switch_meta);
+
+                    if(transferred.isSimilar(spectatorswitch)) {
+                        e.setCancelled(true);
+                    }
+                }
+            }
+
+            return;
+        }
+        if(e.getView().getTopInventory().getType() != InventoryType.CRAFTING) {
+            if(e.getView().getTopInventory().getHolder().equals(e.getWhoClicked())) return;
+            if(e.getCurrentItem() == null) return;
+            if(e.getCurrentItem().getType().equals(Material.PHANTOM_MEMBRANE)) {
+                ItemStack spectatorswitch = new ItemStack(Material.PHANTOM_MEMBRANE);
+                ItemMeta switch_meta = spectatorswitch.getItemMeta();
+                switch_meta.setDisplayName(GRAY + "Phantom Form");
+                ArrayList<String> pearl_lore = new ArrayList();
+                switch_meta.setUnbreakable(true);
+                switch_meta.addEnchant(Enchantment.ARROW_INFINITE, 1, true);
+                switch_meta.addItemFlags(ItemFlag.HIDE_ITEM_SPECIFICS);
+                switch_meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                switch_meta.setLore(pearl_lore);
+                spectatorswitch.setItemMeta(switch_meta);
+
+                if(e.getCurrentItem().isSimilar(spectatorswitch)) {
+                    e.setCancelled(true);
+                }
             }
         }
     }

--- a/src/main/java/me/dueris/genesismc/core/factory/powers/item/EnderPearlThrow.java
+++ b/src/main/java/me/dueris/genesismc/core/factory/powers/item/EnderPearlThrow.java
@@ -4,12 +4,15 @@ import me.dueris.genesismc.core.GenesisMC;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
@@ -21,6 +24,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.util.ArrayList;
 
 import static me.dueris.genesismc.core.factory.powers.Powers.throw_ender_pearl;
+import static org.bukkit.ChatColor.GRAY;
 import static org.bukkit.Material.ENDER_PEARL;
 
 public class EnderPearlThrow implements Listener {
@@ -88,7 +92,6 @@ public class EnderPearlThrow implements Listener {
     @EventHandler
     public void CancelDrop(PlayerDropItemEvent e) {
         ItemStack infinpearl = new ItemStack(ENDER_PEARL);
-
         ItemMeta pearl_meta = infinpearl.getItemMeta();
         pearl_meta.setDisplayName(ChatColor.LIGHT_PURPLE + "Teleport");
         ArrayList<String> pearl_lore = new ArrayList<>();
@@ -101,6 +104,50 @@ public class EnderPearlThrow implements Listener {
             if (e.getItemDrop().getItemStack().isSimilar(infinpearl)) {
                 e.setCancelled(true);
             }
+    }
+
+    @EventHandler
+    public void onTransfer(InventoryClickEvent e) {
+        if(e.getClick().isKeyboardClick()) {
+            if(e.getView().getTopInventory().getType() == InventoryType.CRAFTING) return;
+            if(e.getView().getBottomInventory().getItem(e.getHotbarButton()) != null) {
+                ItemStack transferred = e.getView().getBottomInventory().getItem(e.getHotbarButton());
+                if(transferred.getType().equals(Material.ENDER_PEARL)) {
+                    ItemStack infinpearl = new ItemStack(ENDER_PEARL);
+                    ItemMeta pearl_meta = infinpearl.getItemMeta();
+                    pearl_meta.setDisplayName(ChatColor.LIGHT_PURPLE + "Teleport");
+                    ArrayList<String> pearl_lore = new ArrayList<>();
+                    pearl_meta.setUnbreakable(true);
+                    pearl_meta.addEnchant(Enchantment.ARROW_INFINITE, 1, true);
+                    pearl_meta.setLore(pearl_lore);
+                    infinpearl.setItemMeta(pearl_meta);
+
+                    if(transferred.isSimilar(infinpearl)) {
+                        e.setCancelled(true);
+                    }
+                }
+            }
+
+            return;
+        }
+        if(e.getView().getTopInventory().getType() != InventoryType.CRAFTING) {
+            if(e.getView().getTopInventory().getHolder().equals(e.getWhoClicked())) return;
+            if(e.getCurrentItem() == null) return;
+            if(e.getCurrentItem().getType().equals(Material.ENDER_PEARL)) {
+                ItemStack infinpearl = new ItemStack(ENDER_PEARL);
+                ItemMeta pearl_meta = infinpearl.getItemMeta();
+                pearl_meta.setDisplayName(ChatColor.LIGHT_PURPLE + "Teleport");
+                ArrayList<String> pearl_lore = new ArrayList<>();
+                pearl_meta.setUnbreakable(true);
+                pearl_meta.addEnchant(Enchantment.ARROW_INFINITE, 1, true);
+                pearl_meta.setLore(pearl_lore);
+                infinpearl.setItemMeta(pearl_meta);
+
+                if(e.getCurrentItem().isSimilar(infinpearl)) {
+                    e.setCancelled(true);
+                }
+            }
+        }
     }
 
     @EventHandler

--- a/src/main/java/me/dueris/genesismc/core/factory/powers/item/LaunchAir.java
+++ b/src/main/java/me/dueris/genesismc/core/factory/powers/item/LaunchAir.java
@@ -8,6 +8,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemFlag;
@@ -21,6 +24,7 @@ import java.util.HashMap;
 import java.util.UUID;
 
 import static me.dueris.genesismc.core.factory.powers.Powers.launch_into_air;
+import static me.dueris.genesismc.core.factory.powers.Powers.phantomize;
 import static org.bukkit.ChatColor.GRAY;
 
 public class LaunchAir implements Listener {
@@ -49,6 +53,60 @@ public class LaunchAir implements Listener {
         if (!e.getDrops().contains(launchitem)) return;
         if (launch_into_air.contains(e.getPlayer())) {
             e.getDrops().remove(launchitem);
+        }
+    }
+
+    @EventHandler
+    public void onDrop(PlayerDropItemEvent e) {
+        ItemStack launchitem = new ItemStack(Material.FEATHER);
+        ItemMeta launchmeta = launchitem.getItemMeta();
+        launchmeta.setDisplayName(GRAY + "Launch");
+        launchmeta.addEnchant(Enchantment.ARROW_INFINITE, 1, true);
+        launchitem.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        launchitem.setItemMeta(launchmeta);
+
+        if (e.getItemDrop().getItemStack().isSimilar(launchitem)) {
+            e.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onTransfer(InventoryClickEvent e) {
+        if(e.getClick().isKeyboardClick()) {
+            if(e.getView().getTopInventory().getType() == InventoryType.CRAFTING) return;
+            if(e.getView().getBottomInventory().getItem(e.getHotbarButton()) != null) {
+                ItemStack transferred = e.getView().getBottomInventory().getItem(e.getHotbarButton());
+                if(transferred.getType().equals(Material.FEATHER)) {
+                    ItemStack launchitem = new ItemStack(Material.FEATHER);
+                    ItemMeta launchmeta = launchitem.getItemMeta();
+                    launchmeta.setDisplayName(GRAY + "Launch");
+                    launchmeta.addEnchant(Enchantment.ARROW_INFINITE, 1, true);
+                    launchitem.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                    launchitem.setItemMeta(launchmeta);
+
+                    if(transferred.isSimilar(launchitem)) {
+                        e.setCancelled(true);
+                    }
+                }
+            }
+
+            return;
+        }
+        if(e.getView().getTopInventory().getType() != InventoryType.CRAFTING) {
+            if(e.getView().getTopInventory().getHolder().equals(e.getWhoClicked())) return;
+            if(e.getCurrentItem() == null) return;
+            if(e.getCurrentItem().getType().equals(Material.FEATHER)) {
+                ItemStack launchitem = new ItemStack(Material.FEATHER);
+                ItemMeta launchmeta = launchitem.getItemMeta();
+                launchmeta.setDisplayName(GRAY + "Launch");
+                launchmeta.addEnchant(Enchantment.ARROW_INFINITE, 1, true);
+                launchitem.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                launchitem.setItemMeta(launchmeta);
+
+                if(e.getCurrentItem().isSimilar(launchitem)) {
+                    e.setCancelled(true);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Changes made:

- Phantom Form can't be transferred to other inventories now, fixing issue #20 
- Elytrian Launch item can't be dropped now
- Elytrian Launch item can't be transferred to other inventories now
- Enderian Teleport item can't be transferred to other inventories now