### PR TITLE
Fixed NullPointerException for Object.equals(Object) on InventoryClickEvent

### DIFF
--- a/src/main/java/me/dueris/genesismc/core/factory/powers/entity/Phantomized.java
+++ b/src/main/java/me/dueris/genesismc/core/factory/powers/entity/Phantomized.java
@@ -285,6 +285,7 @@ public class Phantomized extends BukkitRunnable implements Listener {
             if(e.getView().getTopInventory().getType() == InventoryType.CRAFTING) return;
             if(e.getView().getBottomInventory().getItem(e.getHotbarButton()) != null) {
                 ItemStack transferred = e.getView().getBottomInventory().getItem(e.getHotbarButton());
+                if(transferred == null) return;
                 if(transferred.getType().equals(Material.PHANTOM_MEMBRANE)) {
                     ItemStack spectatorswitch = new ItemStack(Material.PHANTOM_MEMBRANE);
                     ItemMeta switch_meta = spectatorswitch.getItemMeta();
@@ -306,7 +307,7 @@ public class Phantomized extends BukkitRunnable implements Listener {
             return;
         }
         if(e.getView().getTopInventory().getType() != InventoryType.CRAFTING) {
-            if(e.getView().getTopInventory().getHolder().equals(e.getWhoClicked())) return;
+            if(e.getView().getTopInventory().getHolder() != null && e.getView().getTopInventory().getHolder().equals(e.getWhoClicked())) return;
             if(e.getCurrentItem() == null) return;
             if(e.getCurrentItem().getType().equals(Material.PHANTOM_MEMBRANE)) {
                 ItemStack spectatorswitch = new ItemStack(Material.PHANTOM_MEMBRANE);

--- a/src/main/java/me/dueris/genesismc/core/factory/powers/item/EnderPearlThrow.java
+++ b/src/main/java/me/dueris/genesismc/core/factory/powers/item/EnderPearlThrow.java
@@ -112,6 +112,7 @@ public class EnderPearlThrow implements Listener {
             if(e.getView().getTopInventory().getType() == InventoryType.CRAFTING) return;
             if(e.getView().getBottomInventory().getItem(e.getHotbarButton()) != null) {
                 ItemStack transferred = e.getView().getBottomInventory().getItem(e.getHotbarButton());
+                if(transferred == null) return;
                 if(transferred.getType().equals(Material.ENDER_PEARL)) {
                     ItemStack infinpearl = new ItemStack(ENDER_PEARL);
                     ItemMeta pearl_meta = infinpearl.getItemMeta();
@@ -131,7 +132,7 @@ public class EnderPearlThrow implements Listener {
             return;
         }
         if(e.getView().getTopInventory().getType() != InventoryType.CRAFTING) {
-            if(e.getView().getTopInventory().getHolder().equals(e.getWhoClicked())) return;
+            if(e.getView().getTopInventory().getHolder() != null && e.getView().getTopInventory().getHolder().equals(e.getWhoClicked())) return;
             if(e.getCurrentItem() == null) return;
             if(e.getCurrentItem().getType().equals(Material.ENDER_PEARL)) {
                 ItemStack infinpearl = new ItemStack(ENDER_PEARL);

--- a/src/main/java/me/dueris/genesismc/core/factory/powers/item/LaunchAir.java
+++ b/src/main/java/me/dueris/genesismc/core/factory/powers/item/LaunchAir.java
@@ -76,6 +76,7 @@ public class LaunchAir implements Listener {
             if(e.getView().getTopInventory().getType() == InventoryType.CRAFTING) return;
             if(e.getView().getBottomInventory().getItem(e.getHotbarButton()) != null) {
                 ItemStack transferred = e.getView().getBottomInventory().getItem(e.getHotbarButton());
+                if(transferred == null) return;
                 if(transferred.getType().equals(Material.FEATHER)) {
                     ItemStack launchitem = new ItemStack(Material.FEATHER);
                     ItemMeta launchmeta = launchitem.getItemMeta();
@@ -93,7 +94,7 @@ public class LaunchAir implements Listener {
             return;
         }
         if(e.getView().getTopInventory().getType() != InventoryType.CRAFTING) {
-            if(e.getView().getTopInventory().getHolder().equals(e.getWhoClicked())) return;
+            if(e.getView().getTopInventory().getHolder() != null && e.getView().getTopInventory().getHolder().equals(e.getWhoClicked())) return;
             if(e.getCurrentItem() == null) return;
             if(e.getCurrentItem().getType().equals(Material.FEATHER)) {
                 ItemStack launchitem = new ItemStack(Material.FEATHER);


### PR DESCRIPTION
Happened at `e.getView().getTopInventory().getHolder()`, added sanitization.