### PR TITLE
Use floodgate api

### DIFF
--- a/origins/build.gradle.kts
+++ b/origins/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     compileOnly("org.reflections:reflections:0.9.12") // - in DependencyLoader - shaded in calio
     compileOnly("org.mineskin:java-client:1.2.4-SNAPSHOT") // - in DependencyLoader
     // Optional Hook
-    compileOnly("org.geysermc.geyser:api:2.2.0-SNAPSHOT")
+    compileOnly("org.geysermc.floodgate:api:2.2.2-SNAPSHOT")
     compileOnly("net.skinsrestorer:skinsrestorer-api:15.0.4")
     compileOnly("me.clip:placeholderapi:2.11.4")
 

--- a/origins/src/main/java/me/dueris/genesismc/factory/powers/apoli/Phasing.java
+++ b/origins/src/main/java/me/dueris/genesismc/factory/powers/apoli/Phasing.java
@@ -39,7 +39,7 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
-import org.geysermc.geyser.api.GeyserApi;
+import org.geysermc.floodgate.api.FloodgateApi;
 
 import java.util.*;
 
@@ -90,7 +90,7 @@ public class Phasing extends PowerType {
 
 	public static boolean isBedrock(Player p) {
 		if (Bukkit.getPluginManager().isPluginEnabled("floodgate")) {
-			return GeyserApi.api().connectionByUuid(p.getUniqueId()) != null;
+			return FloodgateApi.getInstance().isFloodgateId(p.getUniqueId());
 		} else {
 			return false;
 		}


### PR DESCRIPTION
This PR uses floodgate api to check if a player is Bedrock Edition.
cuz some servers only have floodgate installed like a backend server behind the proxy
also floodgate api is a more common-use solution